### PR TITLE
fix(dockerfile): change ttf-freefont by fonts-freefont-ttf debian pac…

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -33,7 +33,7 @@ RUN extBuildDeps=" \
             zip unzip \
             acl \
             iproute2 \
-            ttf-freefont \
+            fonts-freefont-ttf \
             fontconfig \
             dbus \
             openssh-client \


### PR DESCRIPTION
This error to build php service
`Package ttf-freefont is not available, but is referred to by another package.`

Remove `ttf-freefont` and add `fonts-freefont-ttf` for fix error.