### PR TITLE
Explicitly use Debian Stretch as the base image

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/docker-library/php/blob/master/7.3/stretch/fpm/Dockerfile
-FROM php:7.3-fpm
+FROM php:7.3-fpm-stretch
 
 ENV PATH /path/to/bin/folder:$PATH
 ENV PHP_MEMORYLIMIT 2048M


### PR DESCRIPTION
Otherwise we end up with Debian Buster, which results in a package error when running `docker-compose up`:

```E: Package 'ttf-freefont' has no installation candidate 
ERROR: Service 'php' failed to build```