### PR TITLE
Remove GD parameter in Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -40,7 +40,7 @@ RUN extBuildDeps=" \
             libzip-dev \
             sendmail && \
     rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-configure gd --enable-gd-native-ttf --with-jpeg-dir=/usr/lib/x86_64-linux-gnu --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu && \
+    docker-php-ext-configure gd --with-jpeg-dir=/usr/lib/x86_64-linux-gnu --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu && \
     docker-php-ext-configure intl --enable-intl && \
     docker-php-ext-install \
             exif \


### PR DESCRIPTION
```
To enable support for native TrueType string function add --enable-gd-native-ttf . (Effectless as of PHP 5.5.0; removed as of PHP 7.2.0.)
```

https://www.php.net/manual/en/image.installation.php