### PR TITLE
Enable twig namespace 'theme' by default in order to easily use custo…

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -7,7 +7,7 @@ twig:
     paths:
         # Since the name of the theme folder is dynamic, we shouldn't set it here, but dynamically
         # See TwigAwareController::setTwigLoader()
-        # '%kernel.project_dir%/public/theme/%bolt.theme%': ''
+        '%kernel.project_dir%/public/theme/%bolt.theme%': 'theme'
         '%kernel.project_dir%/vendor/bolt/core/templates/': 'bolt'
     default_path: '%kernel.project_dir%/vendor/bolt/core/templates'
     globals:


### PR DESCRIPTION
Enable twig namespace `theme` by default in order to use this to overwrite templates more easily out of the box with bolt/forms.

This PR is linked to https://github.com/bolt/forms/pull/18 in bolt/forms

cc @I-Valchev 