### PR TITLE
Use `@php` in Composer scripts to support actually used PHP binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,18 +28,18 @@
             "bolt:copy-assets": "symfony-cmd"
         },
         "post-create-project-cmd": [
-            "php bin/post-create-project.php",
-            "php bin/console bolt:copy-themes"
+            "@php bin/post-create-project.php",
+            "@php bin/console bolt:copy-themes"
         ],
         "post-install-cmd": [
             "@auto-scripts",
-            "php bin/console extensions:configure --with-config",
-            "php bin/console bolt:info"
+            "@php bin/console extensions:configure --with-config",
+            "@php bin/console bolt:info"
         ],
         "post-update-cmd": [
             "@auto-scripts",
-            "php bin/console extensions:configure",
-            "php bin/console bolt:info"
+            "@php bin/console extensions:configure",
+            "@php bin/console bolt:info"
         ]
     },
     "extra": {


### PR DESCRIPTION
Hi!

When having multiple PHP versions installed, and using the following to install Bolt:

`php7.4 ~/bin/composer create-project bolt/project`

the install fails at the end with:

```
> php bin/console extensions:configure
PHP Parse error:  syntax error, unexpected token "match" in vendor/willdurand/negotiation/src/Negotiation/Negotiator.php on line 41
```

This is due to Composer using the `php` binary, which in my case is PHP 8.

Using `@php` in Composer scripts config make sure Composer reuses the same PHP binary that was used to run Composer in the first place.