### PR TITLE
Remove API endpoint curl check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,6 @@ jobs:
         /home/runner/.symfony/bin/symfony serve --daemon --no-tls
         echo "Check => http://localhost:8000" && curl -fkI http://localhost:8000
         echo "Check => http://localhost:8000/bolt" && curl -fkI http://localhost:8000/bolt
-        echo "Check => http://localhost:8000/api/contents" && curl -fkI http://localhost:8000/api/contents
-        echo "Check => http://localhost:8000/api/fields" && curl -fkI http://localhost:8000/api/fields
-        echo "Check => http://localhost:8000/api/relations" && curl -fkI http://localhost:8000/api/relations
     - name: Validate composer.json
       run: composer validate --no-check-publish
     - name: Run PHP-CS-Fixer


### PR DESCRIPTION
Removing the API endpoint curl check. It no longer works in 5.1, because the API is protected behind a `ROLE_WEBSERVICE` role.

Instead, we'll do the API check in `bolt/core` from now on :-)